### PR TITLE
Specify UTF-8 encoding when parsing rest api response

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/StashBranchParameter/StashConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/StashBranchParameter/StashConnector.java
@@ -158,7 +158,7 @@ public class StashConnector
 			{
 				HttpEntity entity = response.getEntity();
 				StringWriter writer = new StringWriter();
-				IOUtils.copy(entity.getContent(), writer);
+				IOUtils.copy(entity.getContent(), writer, "UTF-8");
 
 				return JSONObject.fromObject(writer.toString());
 			}


### PR DESCRIPTION
If stash response contains multibyte characters, the parsing response fails at `StashConnector` as below. To fix this problem, I added the code specifing UTF-8 encoding.

```
Caused by:
net.sf.json.JSONException: Expected a ',' or '}' at character 1220 of {"size":172,"limit":1000,"isLastPage":true,"values":[{"slug": ... }],"start":0}
        ...
        at net.sf.json.util.JSONTokener.syntaxError(JSONTokener.java:499)
        at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:1043)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
        at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
        at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:156)
        at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:348)
        at net.sf.json.JSONArray._fromJSONTokener(JSONArray.java:1131)
        at net.sf.json.JSONArray.fromObject(JSONArray.java:125)
        at net.sf.json.util.JSONTokener.nextValue(JSONTokener.java:351)
        at net.sf.json.JSONObject._fromJSONTokener(JSONObject.java:955)
        at net.sf.json.JSONObject._fromString(JSONObject.java:1145)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:162)
        at net.sf.json.JSONObject.fromObject(JSONObject.java:132)
        at org.jenkinsci.plugins.StashBranchParameter.StashConnector.getJson(StashConnector.java:163)
        at org.jenkinsci.plugins.StashBranchParameter.StashConnector.getRepositories(StashConnector.java:131)
        at org.jenkinsci.plugins.StashBranchParameter.StashBranchParameterDescriptor.doFillRepositoryItems(StashBranchParameterDescriptor.java:167)
