### PR TITLE
Implemented paging for repositories that have more than 1000 remote branches…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/StashBranchParameter/StashConnector.java
+++ b/src/main/java/org/jenkinsci/plugins/StashBranchParameter/StashConnector.java
@@ -169,20 +169,22 @@ public class StashConnector
     {
         List<JSONObject> jsonPages = new ArrayList<JSONObject>();
         String startPath = path;
-        path += params;
-        JSONObject currentJson = getJson(path);
-        jsonPages.add(currentJson);
-        //TODO: I guess it should be recursive here
-        for (int attempt=0; attempt<100; attempt++)
-        {
-            if (currentJson.getBoolean("isLastPage"))
-            {
-                break;
-            }
-            path = startPath + params +"&start=" + currentJson.getInt("nextPageStart");
-            currentJson = getJson(path);
-            jsonPages.add(currentJson);
-        }
+		int nextPageStart = 0;
+		JSONObject currentJson;
+        do
+		{
+			path = startPath + params +"&start=" + nextPageStart;
+			currentJson = getJson(path);
+			jsonPages.add(currentJson);
+			if(currentJson.has("isLastPage"))
+			{
+				if (!currentJson.getBoolean("isLastPage"))
+				{
+					nextPageStart = currentJson.getInt("nextPageStart");
+				}
+			}
+        }while(!currentJson.getBoolean("isLastPage"));
+
         return jsonPages;
     }
 


### PR DESCRIPTION
When repository suddenly has more than 1000 remote branches, tags or other entries under specific category. this plugin returns only first 1000. Increasing of request "limit" entails nothing because Stash server itself has default limit up to 1000 entries. Luckily Stash REST API supports paging. And this commit tries to accommodate it. 