### PR TITLE
pom.xml: Use GitHub for plugin's documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.level>7</java.level>
     </properties>
 
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/stash-branch-parameters-plugin</url>
+    <url>https://github.com/jenkinsci/stash-branch-parameters-plugin</url>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
The URL was incorrect. The correct URL on Jenkins Wiki is
https://wiki.jenkins.io/display/JENKINS/StashBranchParameter

However, that page contains almost no information and cannot be modified
because Jenkins Wiki is currently read-only.

Plugin authors are encouraged to use GitHub for plugin documentation:
https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/

Set URL to the GitHub page of the project as recommended. The link in the
Jenkins plugin manager will lead directly to the GitHub page.

The plugin page on plugins.jenkins.io will be updated shortly after the
next version of this plugin is released.